### PR TITLE
fix: flatten Helm values files

### DIFF
--- a/flagsmith-on-eks/flagsmith-values.yaml
+++ b/flagsmith-on-eks/flagsmith-values.yaml
@@ -1,3 +1,6 @@
+influxdb2:
+  enabled: false
+
 postgresql:
   enabled: false
 
@@ -7,3 +10,9 @@ databaseExternal:
     enabled: true
     name: flagsmith-db
     key: url
+
+service:
+  frontend:
+    type: LoadBalancer
+  api:
+    type: LoadBalancer

--- a/flagsmith-on-eks/main.tf
+++ b/flagsmith-on-eks/main.tf
@@ -18,7 +18,6 @@ resource "helm_release" "flagsmith" {
   chart      = "flagsmith"
 
   values = [
-    file("${path.module}/../../flagsmith-values.yaml"),
-    file("${path.module}/flagsmith-values-rds.yaml")
+    file("${path.module}/flagsmith-values.yaml")
   ]
 }


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [X] I have filled in the "Changes" section below?
- [X] I have filled in the "How did you test this code" section below?

## Changes

This removes the extra `flagsmith-values.yaml` at the repository root.
 
## How did you test this code?

Ran `terraform plan` and confirmed no issues.