### PR TITLE
chore: Add `CODEOWNERS`

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @flagsmith/flagsmith-infrastructure

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,2 @@
-* @flagsmith/flagsmith-infrastructure
+* @Flagsmith/flagsmith-infrastructure 
+


### PR DESCRIPTION
Adds a root `/CODEOWNERS` file with the designated owning team.

Closes #10.
